### PR TITLE
Trim inclusion of vendor charls lib to the bare essentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,20 @@ links = "charls"
 name = "charls-sys"
 readme = "README.md"
 version = "2.4.3"
+include = [
+    "LICENSE.md",
+    "README.md",
+    "build.rs",
+    "wrapper.h",
+    "src",
+    "charls/LICENSE.md",
+    "charls/CMakeLists.txt",
+    "charls/CMakePresets.json",
+    "charls/CharLS.sln",
+    "charls/CharLS.sln.properties",
+    "charls/include",
+    "charls/src",
+]
 
 [dependencies]
 

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,9 @@ fn main() {
     let dst = cmake::Config::new("charls")
         .define("BUILD_SHARED_LIBS", "0")
         .define("CMAKE_LINK_DEPENDS_USE_LINKER", "0")
+        .define("CHARLS_BUILD_TESTS", "0")
+        .define("CHARLS_BUILD_FUZZ_TEST", "0")
+        .define("CHARLS_BUILD_SAMPLES", "0")
         .always_configure(true)
         .build();
 


### PR DESCRIPTION
This reduces the uploaded/downloaded package `.crate` file size from 9.1M to 86k, while also making builds faster. From the tests I did so far (including patching this dependency over at dicom-rs) it seems to operate well without side effects.

- add `include` field in Cargo manifest to trim unnecessary parts from the charls submodule repository
- define `CHARLS_BUILD_*` options in build.rs so that tests and sample binary are not built

