### PR TITLE
Add optional `vcpkg` feature to build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ name = "charls-sys"
 version = "2.4.3"
 dependencies = [
  "cmake",
+ "vcpkg",
 ]
 
 [[package]]
@@ -23,3 +24,9 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ version = "2.4.3"
 
 [build-dependencies]
 cmake = "0.1"
+vcpkg = { version = "0.2.15", optional = true }
 
 [features]
 default = []
 static = []
+vcpkg = ["dep:vcpkg"]

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,21 @@
 fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
 
-    let dst = cmake::Config::new("charls")
-        .define("BUILD_SHARED_LIBS", "0")
-        .define("CMAKE_LINK_DEPENDS_USE_LINKER", "0")
-        .always_configure(true)
-        .build();
+    #[cfg(not(feature = "vcpkg"))]
+    {
+        let dst = cmake::Config::new("charls")
+            .define("BUILD_SHARED_LIBS", "0")
+            .define("CMAKE_LINK_DEPENDS_USE_LINKER", "0")
+            .always_configure(true)
+            .build();
+        println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    }
+
+    #[cfg(feature = "vcpkg")]
+    vcpkg::Config::new()
+        .emit_includes(true)
+        .find_package("charls")
+        .unwrap();
 
     #[cfg(feature = "static")]
     {
@@ -28,5 +38,4 @@ fn main() {
             _ => {}
         }
     }
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
 }


### PR DESCRIPTION
### Description

Introduce support for an optional `vcpkg` feature in `build.rs`. Updates include a conditional build system that utilizes `vcpkg` when the feature is opted-in. Dependencies in `Cargo.toml` and `Cargo.lock` were adjusted accordingly to make `vcpkg` an optional build dependency. This change provides more flexibility in managing builds based on feature selection.
